### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/bell345/xbrz-rs/compare/v0.1.0...v0.1.1) - 2024-07-28
+
+### Other
+- changelog fix
+- release
+
 ## [0.1.0](https://github.com/bell345/xbrz-rs/releases/tag/v0.1.0) - 2024-07-28
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "xbrz-rs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bytemuck",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xbrz-rs"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Thomas Bell <github.com/bell345>", "Zenju <zenju@gmx.de>"]
 license = "GPL-3.0-only"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `xbrz-rs`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/bell345/xbrz-rs/compare/v0.1.0...v0.1.1) - 2024-07-28

### Other
- changelog fix
- release
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).